### PR TITLE
Added encodeURI for player#lavaSearch

### DIFF
--- a/src/managers/Player.ts
+++ b/src/managers/Player.ts
@@ -198,6 +198,8 @@ export class Player {
     options: { source?: "yt" | "sc"; add?: boolean }
   ): Promise<Track[] | Playlist> {
     return new Promise(async (resolve, reject) => {
+      query = encodeURI(query)
+      
       const search = new RegExp(/^https?:\/\//g).test(query)
         ? query
         : `${options.source || "yt"}search:${query}`;

--- a/src/managers/Player.ts
+++ b/src/managers/Player.ts
@@ -198,10 +198,8 @@ export class Player {
     options: { source?: "yt" | "sc"; add?: boolean }
   ): Promise<Track[] | Playlist> {
     return new Promise(async (resolve, reject) => {
-      query = encodeURI(query)
-      
       const search = new RegExp(/^https?:\/\//g).test(query)
-        ? query
+        ? encodeURI(query)
         : `${options.source || "yt"}search:${query}`;
 
       const { loadType, playlistInfo, tracks, exception } = await (


### PR DESCRIPTION
I have added `encodeURI` for `player#lavaSearch` if I search with some none-english chars, it causes error.